### PR TITLE
Remove 32 bit binary support

### DIFF
--- a/factorio
+++ b/factorio
@@ -556,10 +556,6 @@ function get_bin_version(){
   as_user "$BINARY --version |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1"
 }
 
-function get_bin_arch(){
-  as_user "$BINARY --version |egrep '^Binary version: ' |egrep -o '[0-9]{2}'"
-}
-
 function update(){
   if ! [ -e "${UPDATE_SCRIPT}" ]; then
     echo "Failed to find update script, blatantly refusing to continue!"
@@ -576,9 +572,9 @@ function update(){
   fi
 
   if [ ${HEADLESS} -gt 0 ]; then
-    package="core-linux_headless$(get_bin_arch)"
+    package="core-linux_headless64"
   else
-    package="core-linux$(get_bin_arch)"
+    package="core-linux64"
   fi
 
   version=$(get_bin_version)


### PR DESCRIPTION
- Factorio has terminated 32 bit binary support 8 years ago (https://www.factorio.com/blog/post/fff-158) and only supports 64 bit binaries since version 0.15. The release of 2.x changed the version output of the binary, breaking binary arch detection. Instead of fixing this for a feature not support since years, this change removes it.